### PR TITLE
Task/kt 410 implement retry mechanism for who is

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,7 +40,10 @@ func main() {
 	}
 
 	// Services
-	whoIsService := services.NewWhoIsService()
+	whoIsService := services.NewWhoIsService(&services.WhoIsServiceOptions{
+		MaxRetries: 3,
+		RetryDelay: 5 * time.Second,
+	})
 	dnsLookupService := services.NewDNSLookupService()
 	harvesterService := services.NewHarvesterService()
 
@@ -66,7 +69,6 @@ func main() {
 	}
 
 	waitForShutdown()
-
 }
 
 func waitForShutdown() {

--- a/pkg/services/whois.go
+++ b/pkg/services/whois.go
@@ -63,7 +63,7 @@ func (s *WhoIsService) RunScan(ctx context.Context, domain string) (tools.ToolRe
 			break
 		} else {
 			slog.Warn("WhoIs request failed, retrying",
-				slog.Int("attempt", attempt),
+				slog.Int("attempt", attempt+1),
 				slog.Any("whois_error", err),
 				slog.Duration("delay", s.retryDelay))
 		}

--- a/pkg/services/whois.go
+++ b/pkg/services/whois.go
@@ -71,6 +71,13 @@ func (s *WhoIsService) RunScan(ctx context.Context, domain string) (tools.ToolRe
 			break
 		}
 	}
+	// If err is not nil after the retry loop
+	if err != nil {
+		slog.Error("WhoIs request failed after max retries",
+			slog.Int("max_retries", s.maxRetries),
+			slog.Any("error", err))
+		return tools.ToolResult{}, err
+	}
 
 	parsedResult, err := whoisparser.Parse(whoIsRaw)
 	if err != nil {

--- a/pkg/services/whois.go
+++ b/pkg/services/whois.go
@@ -57,18 +57,19 @@ func (s *WhoIsService) RunScan(ctx context.Context, domain string) (tools.ToolRe
 	var whoIsRaw string
 	var err error
 
-	for attempt := 0; attempt < s.maxRetries; attempt++ {
+	for retryCount := 0; retryCount < s.maxRetries; retryCount++ {
+		if retryCount > 0 { // Log only on retries, not on the initial attempt
+			newRetryDelay := s.calculateRetryDelay(retryCount)
+			slog.Warn("WhoIs request failed, retrying",
+				slog.Int("attempt", retryCount+1),
+				slog.Any("whois_error", err),
+				slog.Duration("delay", newRetryDelay))
+			time.Sleep(newRetryDelay)
+		}
 		whoIsRaw, err = whois.Whois(domain)
 		if err == nil {
 			break
-		} else {
-			slog.Warn("WhoIs request failed, retrying",
-				slog.Int("attempt", attempt+1),
-				slog.Any("whois_error", err),
-				slog.Duration("delay", s.retryDelay))
 		}
-		newRetryDelay := s.calculateRetryDelay(attempt)
-		time.Sleep(newRetryDelay)
 	}
 
 	parsedResult, err := whoisparser.Parse(whoIsRaw)

--- a/pkg/services/whois.go
+++ b/pkg/services/whois.go
@@ -13,37 +13,67 @@ import (
 )
 
 type WhoIsService struct {
-	Logger *slog.Logger
+	maxRetries int
+	retryDelay time.Duration
+}
+
+type WhoIsServiceOptions struct {
+	MaxRetries int
+	RetryDelay time.Duration
 }
 
 var _ interfaces.IWhoIsService = (*WhoIsService)(nil)
 
-func NewWhoIsService() *WhoIsService {
+func NewWhoIsService(opts *WhoIsServiceOptions) *WhoIsService {
+	if opts == nil {
+		opts = &WhoIsServiceOptions{}
+	}
+	maxRetries := opts.MaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 3
+	}
+	retryDelay := opts.RetryDelay
+	if retryDelay <= 0 {
+		retryDelay = 5 * time.Second
+	}
+
 	return &WhoIsService{
-		Logger: slog.New(slog.Default().Handler()),
+		maxRetries: maxRetries,
+		retryDelay: retryDelay,
 	}
 }
 
 func (s *WhoIsService) RunScan(ctx context.Context, domain string) (tools.ToolResult, error) {
-	s.Logger.Info("Running WhoIs scanner...")
+	slog.Info("Running WhoIs scanner...")
 
 	select {
 	case <-ctx.Done():
-		s.Logger.Warn("Context cancelled during WhoIs search", "target", domain)
+		slog.Warn("Context cancelled during WhoIs search", "target", domain)
 		return tools.ToolResult{}, ctx.Err()
 	default:
 		// Proceed with the operation
 	}
 
-	whoIsRaw, err := whois.Whois(domain)
-	if err != nil {
-		s.Logger.Error("Error fetching WHOIS", "target", domain, "error", err)
-		return tools.ToolResult{}, err
+	var whoIsRaw string
+	var err error
+
+	for attempt := 0; attempt < s.maxRetries; attempt++ {
+		whoIsRaw, err = whois.Whois(domain)
+		if err == nil {
+			break
+		} else {
+			slog.Warn("WhoIs request failed, retrying",
+				slog.Int("attempt", attempt),
+				slog.Any("whois_error", err),
+				slog.Duration("delay", s.retryDelay))
+		}
+		newRetryDelay := s.calculateRetryDelay(attempt)
+		time.Sleep(newRetryDelay)
 	}
 
 	parsedResult, err := whoisparser.Parse(whoIsRaw)
 	if err != nil {
-		s.Logger.Error("Error parsing WHOIS data", "target", domain, "error", err)
+		slog.Error("Error parsing WHOIS data", "target", domain, "error", err)
 		return tools.ToolResult{}, err
 	}
 
@@ -54,4 +84,16 @@ func (s *WhoIsService) RunScan(ctx context.Context, domain string) (tools.ToolRe
 		},
 		Timestamp: time.Now().UTC(),
 	}, nil
+}
+
+func (s *WhoIsService) calculateRetryDelay(attempt int) time.Duration {
+	// Exponential backoff with jitter
+	delay := s.retryDelay * time.Duration(1<<uint(attempt))
+	jitter := time.Duration(int64(float64(delay) * 0.2)) // +/- 20% jitter
+	delay += jitter
+
+	if delay > 15*time.Second {
+		delay = 15 * time.Second
+	}
+	return delay
 }


### PR DESCRIPTION
This pull request includes enhancements to the `WhoIsService` to add retry logic and improve error handling, as well as some minor cleanups in the `main` function.

Enhancements to `WhoIsService`:

* [`pkg/services/whois.go`](diffhunk://#diff-44e10da6c4c74ebb975f0b2d4c8581a7faf1c7d3a766bb9763c0b2469596252fL16-R77): Introduced `WhoIsServiceOptions` to configure `maxRetries` and `retryDelay`, and updated the `NewWhoIsService` constructor to accept these options. Added retry logic with exponential backoff and jitter in the `RunScan` method. [[1]](diffhunk://#diff-44e10da6c4c74ebb975f0b2d4c8581a7faf1c7d3a766bb9763c0b2469596252fL16-R77) [[2]](diffhunk://#diff-44e10da6c4c74ebb975f0b2d4c8581a7faf1c7d3a766bb9763c0b2469596252fR89-R100)

Minor cleanups in `main` function:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L43-R46): Updated the instantiation of `WhoIsService` to pass the new options. Removed an unnecessary blank line in the `waitForShutdown` function. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L43-R46) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L69)